### PR TITLE
Fixing optional parameter in fputs

### DIFF
--- a/res/php-5.2-core-api/standard.php
+++ b/res/php-5.2-core-api/standard.php
@@ -6544,7 +6544,7 @@ function fwrite ($handle, $string, $length = null) {}
  *
  * @jms-builtin
  */
-function fputs ($fp, $str, $length) {}
+function fputs ($fp, $str, $length = null) {}
 
 /**
  * Makes directory

--- a/res/php-5.3-core-api/standard.php
+++ b/res/php-5.3-core-api/standard.php
@@ -6427,7 +6427,7 @@ function fwrite ($handle, $string, $length = null) {}
  *
  * @jms-builtin
  */
-function fputs ($fp, $str, $length) {}
+function fputs ($fp, $str, $length = null) {}
 
 /**
  * Makes directory

--- a/res/php-5.4-core-api/standard.php
+++ b/res/php-5.4-core-api/standard.php
@@ -6887,7 +6887,7 @@ function fwrite ($handle, $string, $length = null) {}
  * @param $length [optional]
  * @jms-builtin
  */
-function fputs ($fp, $str, $length) {}
+function fputs ($fp, $str, $length = null) {}
 
 /**
  * (PHP 4, PHP 5)<br/>


### PR DESCRIPTION
Not sure how these files are generated, but `fputs` is an alias of `fwrite` and the third parameter was incorrectly shown to have no default value.
